### PR TITLE
Update Chronosphere documentation link in README.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,4 +6,6 @@
 
 # v0.9.0
 
-Initial release of the Chronosphere Pulumi provider.
+- Initial release of the Chronosphere Pulumi provider.
+- Update link in `README.md` to point to a new page in the Chronosphere documentation
+  for the Chronosphere Pulumi provider.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The Chronosphere Pulumi Provider allows [Pulumi](https://www.pulumi.com/) to manage supported [Chronosphere resources](https://docs.chronosphere.io/administer).
 
-- [Documentation]([https://docs.chronosphere.io/administer](https://docs.chronosphere.io/administer/infrastructure/pulumi))
+- [Documentation](https://docs.chronosphere.io/administer/infrastructure/pulumi)
 
 ## Contact support
 


### PR DESCRIPTION
Updates the documentation link to point to a new page for the Chronosphere Pulumi provider.