### PR TITLE
Fix Pulumi Provider download URL

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -50,11 +50,12 @@ func Provider() tfbridge.ProviderInfo {
 		Keywords:       []string{"chronosphere", "observability", "prometheus"},
 		License:        "Apache-2.0",
 		// LogoURL:        "",
-		DisplayName: "Chronosphere",
-		Publisher:   "Chronosphere",
-		Homepage:    "https://chronosphere.io",
-		Repository:  "https://github.com/chronosphereio/pulumi-chronosphere",
-		Version:     "v0.1.0",
+		DisplayName:       "Chronosphere",
+		Publisher:         "Chronosphere",
+		Homepage:          "https://chronosphere.io",
+		Repository:        "https://github.com/chronosphereio/pulumi-chronosphere",
+		PluginDownloadURL: "github://api.github.com/chronosphereio",
+		Version:           "v0.1.0",
 		Config: map[string]*tfbridge.SchemaInfo{
 			"org": {
 				Default: &tfbridge.DefaultInfo{EnvVars: []string{"CHRONOSPHERE_ORG", "CHRONOSPHERE_ORG_NAME"}},


### PR DESCRIPTION
When PluginDownloadURL is not set, Pulumi assumes that the
plugin is downloaded from the official repository in the
Pulumi github organization. As a result, in order to install
the Chronosphere provider you need to run the
`pulumi plugin install` command with a `--server` argument
pointing it at the right place to download it.

This change simply sets the right download URL so that this
won't be necessary anymore