### PR TITLE
[sc-118429] Port Chronosphere specific terraform plugin SDK fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+Fixed:
+- Fixed a bug where Set types in terraform plugin SDK could have extra, empty values.
+
 ## v0.9.4
 
 Added:

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -15,6 +15,10 @@ replace (
 	// this dependency is sensitive and is worth doing carefully (such as reading release notes)
 	// and not simply rely on passing tests for the upgrade.
 	github.com/hashicorp/terraform-plugin-framework => github.com/pulumi/terraform-plugin-framework v0.0.0-20230922145027-1535d08c1d47
+
+	// NOTE: We have changed this replace statement to point to a branch in the Chronosphere fork of the plugin SDK. This branch
+	//       is based off of the Pulumi fork but adds some necessary fixes that Chronosphere has made over the years for our
+	//       Terraform Provider that is used for bridging.
 	// github.com/hashicorp/terraform-plugin-sdk/v2 => github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20230912190043-e6d96b3b8f7e
 	github.com/hashicorp/terraform-plugin-sdk/v2 => github.com/chronosphereio/terraform-plugin-sdk/v2 v2.0.0-20241216201251-9f5fae072741
 

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -15,7 +15,9 @@ replace (
 	// this dependency is sensitive and is worth doing carefully (such as reading release notes)
 	// and not simply rely on passing tests for the upgrade.
 	github.com/hashicorp/terraform-plugin-framework => github.com/pulumi/terraform-plugin-framework v0.0.0-20230922145027-1535d08c1d47
-	github.com/hashicorp/terraform-plugin-sdk/v2 => github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20230912190043-e6d96b3b8f7e
+	// github.com/hashicorp/terraform-plugin-sdk/v2 => github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20230912190043-e6d96b3b8f7e
+	github.com/hashicorp/terraform-plugin-sdk/v2 => github.com/chronosphereio/terraform-plugin-sdk/v2 v2.0.0-20241216201251-9f5fae072741
+
 	github.com/hashicorp/terraform-provider-aws => ../upstream
 	github.com/hashicorp/vault => github.com/hashicorp/vault v1.2.0
 )

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -929,6 +929,8 @@ github.com/checkpoint-restore/go-criu/v5 v5.3.0/go.mod h1:E/eQpaFtUKGOOSEBZgmKAc
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
 github.com/cheggaaa/pb v1.0.29 h1:FckUN5ngEk2LpvuG0fw1GEFx6LtyY2pWI/Z2QgCnEYo=
 github.com/cheggaaa/pb v1.0.29/go.mod h1:W40334L7FMC5JKWldsTWbdGjLo0RxUKK73K+TuPxX30=
+github.com/chronosphereio/terraform-plugin-sdk/v2 v2.0.0-20241216201251-9f5fae072741 h1:uMQaj7cOllk66pPZYBleDx8Io0BGg2ROucFEZstnOb8=
+github.com/chronosphereio/terraform-plugin-sdk/v2 v2.0.0-20241216201251-9f5fae072741/go.mod h1:qH/34G25Ugdj5FcM95cSoXzUgIbgfhVLXCcEcYaMwq8=
 github.com/chronosphereio/terraform-provider-chronosphere v1.6.1 h1:FdlqRYZN8bwWE8RWLiwvh2YTOEqjyonf3W8NS3Pl+KA=
 github.com/chronosphereio/terraform-provider-chronosphere v1.6.1/go.mod h1:Aj+ZF3Ncra9gNWU96t3Fk4KghEMv3h8bW8gyeWXZaSo=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
@@ -2207,8 +2209,6 @@ github.com/pulumi/schema-tools v0.1.2 h1:Fd9xvUjgck4NA+7/jSk7InqCUT4Kj940+EcnbQK
 github.com/pulumi/schema-tools v0.1.2/go.mod h1:62lgj52Tzq11eqWTIaKd+EVyYAu5dEcDJxMhTjvMO/k=
 github.com/pulumi/terraform-diff-reader v0.0.2 h1:kTE4nEXU3/SYXESvAIem+wyHMI3abqkI3OhJ0G04LLI=
 github.com/pulumi/terraform-diff-reader v0.0.2/go.mod h1:sZ9FUzGO+yM41hsQHs/yIcj/Y993qMdBxBU5mpDmAfQ=
-github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20230912190043-e6d96b3b8f7e h1:blSirnXqvm8JXLxwxelsBroUNRhOHakDO7cgJUYTdpQ=
-github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20230912190043-e6d96b3b8f7e/go.mod h1:qH/34G25Ugdj5FcM95cSoXzUgIbgfhVLXCcEcYaMwq8=
 github.com/rakyll/embedmd v0.0.0-20171029212350-c8060a0752a2/go.mod h1:7jOTMgqac46PZcF54q6l2hkLEG8op93fZu61KmxWDV4=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=


### PR DESCRIPTION
This PR ports several fixes that Chronosphere has made
to the Terraform Plugin SDK onto the fork that Pulumi
maintains for its Terraform Bridge SDK.

- Fix for TypeSet applying with unexpected empty element
- Use StateFunc when generating hashes for set elements

sc-118429