### PR TITLE
Fix release: bump Python from 3.9 to 3.12 [ignore-release]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,4 +126,4 @@ jobs:
         nodeversion:
           - 20.x
         pythonversion:
-          - "3.9"
+          - "3.12"


### PR DESCRIPTION
GitHub Actions runners no longer ship Python 3.9, so the Setup
Python step in the SDK publish job failed with "Version 3.9 with
arch x64 not found", canceling the whole release.

Bump the SDK publish matrix to Python 3.12, matching the version
already used in ci.yml (3.12.2).